### PR TITLE
Remove nuget for references

### DIFF
--- a/tests/Csla.DataPortalExtensionsGenerator.Tests/Ossendorf.Csla.DataPortalExtensionsGenerator.Tests.csproj
+++ b/tests/Csla.DataPortalExtensionsGenerator.Tests/Ossendorf.Csla.DataPortalExtensionsGenerator.Tests.csproj
@@ -8,7 +8,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Basic.Reference.Assemblies.Net70" Version="1.4.5" />
         <PackageReference Include="Csla" Version="7.0.3" />
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/tests/Csla.DataPortalExtensionsGenerator.Tests/TestHelper.cs
+++ b/tests/Csla.DataPortalExtensionsGenerator.Tests/TestHelper.cs
@@ -31,15 +31,18 @@ namespace GeneratorTests {{
             syntaxTrees.Add(CSharpSyntaxTree.ParseText(additionalSource));
         }
 
+        var references = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrWhiteSpace(a.Location))
+            .Select(a => MetadataReference.CreateFromFile(a.Location))
+            .Concat(new[] {
+                MetadataReference.CreateFromFile(typeof(FetchAttribute).Assembly.Location)
+            });
+
         var compilation = CSharpCompilation.Create(
-                assemblyName: "Tests",
+                assemblyName: "GeneratorTests",
                 syntaxTrees: syntaxTrees,
-                references: new[] {
-                    MetadataReference.CreateFromFile(typeof(FetchAttribute).Assembly.Location),
-                    Basic.Reference.Assemblies.Net70.References.SystemRuntime,
-                    Basic.Reference.Assemblies.Net70.References.SystemCore
-                }
-                , new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                references: references,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
             );
 
         var generator = new DataPortalExtensionsGenerator();


### PR DESCRIPTION
Resolve references like NetEscapades.EnumGenerators.Tests