### PR TITLE
Fix analyzers matching types by leaf namespace instead of full metadata name

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "defaultPermissionMode": "plan"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,10 @@ Consuming projects can set these properties to customize generated method names:
 
 Property names are defined in `ConfigConstants.cs`. Generated methods are intentionally not async-suffixed by design.
 
+## Code style
+
+- All methods, including static local functions, must use **PascalCase** naming.
+
 ## Versioning
 
 Uses MinVer — version is derived from git tags with prefix `v` (e.g., `v1.2.3`). Minimum version: `0.1`, pre-release identifier: `preview.0`.

--- a/src/Csla.DataPortalExtensionGenerator.Analyzers/CompilationHelper.cs
+++ b/src/Csla.DataPortalExtensionGenerator.Analyzers/CompilationHelper.cs
@@ -1,0 +1,9 @@
+using Microsoft.CodeAnalysis;
+
+namespace Ossendorf.Csla.DataPortalExtensionGenerator.Analyzers;
+
+internal static class CompilationHelper {
+
+    internal static INamedTypeSymbol? ResolveType(Compilation compilation, string metadataName)
+        => compilation.GetTypeByMetadataName(metadataName);
+}

--- a/src/Csla.DataPortalExtensionGenerator.Analyzers/DataPortalInterfaceUsedAsNotInjectedParamterAnalyzer.cs
+++ b/src/Csla.DataPortalExtensionGenerator.Analyzers/DataPortalInterfaceUsedAsNotInjectedParamterAnalyzer.cs
@@ -30,26 +30,58 @@ public sealed class DataPortalInterfaceUsedAsNotInjectedParamterAnalyzer : Diagn
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
 
-        context.RegisterSymbolAction(AnalyzePortalMethod, SymbolKind.Method);
+        context.RegisterCompilationStartAction(compilationStart => {
+            var compilation = compilationStart.Compilation;
+
+            var dataPortal = CompilationHelper.ResolveType(compilation, "Csla.IDataPortal`1");
+            if (dataPortal is null) {
+                return;
+            }
+
+            var childDataPortal = CompilationHelper.ResolveType(compilation, "Csla.IChildDataPortal`1");
+            if (childDataPortal is null) {
+                return;
+            }
+
+            var portalAttributeTypes = ResolvePortalAttributeTypes(compilation);
+            if (portalAttributeTypes.IsEmpty) {
+                return;
+            }
+
+            var injectAttribute = CompilationHelper.ResolveType(compilation, "Csla.InjectAttribute")!;
+
+            compilationStart.RegisterSymbolAction(ctx => AnalyzePortalMethod(ctx, dataPortal, childDataPortal, portalAttributeTypes, injectAttribute), SymbolKind.Method);
+        });
     }
 
-    private static readonly ImmutableHashSet<string> _portalAttributes = ImmutableHashSet.Create(
-        "CreateAttribute",
-        "FetchAttribute",
-        "InsertAttribute",
-        "UpdateAttribute",
-        "ExecuteAttribute",
-        "DeleteAttribute",
-        "DeleteSelfAttribute",
-        "CreateChildAttribute",
-        "FetchChildAttribute",
-        "InsertChildAttribute",
-        "UpdateChildAttribute",
-        "DeleteSelfChildAttribute",
-        "ExecuteChildAttribute"
-    );
+    private static readonly ImmutableArray<string> _portalAttributeMetadataNames = [
+        "Csla.CreateAttribute",
+        "Csla.FetchAttribute",
+        "Csla.InsertAttribute",
+        "Csla.UpdateAttribute",
+        "Csla.ExecuteAttribute",
+        "Csla.DeleteAttribute",
+        "Csla.DeleteSelfAttribute",
+        "Csla.CreateChildAttribute",
+        "Csla.FetchChildAttribute",
+        "Csla.InsertChildAttribute",
+        "Csla.UpdateChildAttribute",
+        "Csla.DeleteSelfChildAttribute",
+        "Csla.ExecuteChildAttribute"
+    ];
 
-    private void AnalyzePortalMethod(SymbolAnalysisContext context) {
+    private static ImmutableHashSet<INamedTypeSymbol> ResolvePortalAttributeTypes(Compilation compilation) {
+        var builder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+        foreach (var metadataName in _portalAttributeMetadataNames) {
+            var type = compilation.GetTypeByMetadataName(metadataName);
+            if (type is not null) {
+                builder.Add(type);
+            }
+        }
+        return builder.ToImmutable();
+    }
+
+    private static void AnalyzePortalMethod(SymbolAnalysisContext context, INamedTypeSymbol dataPortal, INamedTypeSymbol childDataPortal, ImmutableHashSet<INamedTypeSymbol> portalAttributeTypes, INamedTypeSymbol injectAttribute) {
         if (context.IsGeneratedCode) {
             return;
         }
@@ -61,36 +93,49 @@ public sealed class DataPortalInterfaceUsedAsNotInjectedParamterAnalyzer : Diagn
             return;
         }
 
-        if (!HasCslaAttribute(methodSymbol, _portalAttributes.Contains, context.CancellationToken)) {
+        if (!HasPortalAttribute(methodAttributes, portalAttributeTypes, context.CancellationToken)) {
             return;
         }
 
         foreach (var parameter in methodSymbol.Parameters) {
+            var parameterOriginalType = parameter.Type.OriginalDefinition;
 
-            if (parameter.Type is not { ContainingNamespace.Name: "Csla", Name: "IDataPortal" or "IChildDataPortal" }) {
+            if (!SymbolEqualityComparer.Default.Equals(parameterOriginalType, dataPortal) &&
+                !SymbolEqualityComparer.Default.Equals(parameterOriginalType, childDataPortal)) {
                 continue;
             }
 
-            if (HasCslaAttribute(parameter, static name => name == "InjectAttribute", context.CancellationToken)) {
+            if (HasInjectAttribute(parameter, injectAttribute, context.CancellationToken)) {
                 continue;
             }
 
-            var parameterSyntax = parameter.DeclaringSyntaxReferences.First().GetSyntax();
+            var parameterSyntax = parameter.DeclaringSyntaxReferences[0].GetSyntax();
             context.ReportDiagnostic(Diagnostic.Create(_rule, parameterSyntax.GetLocation(), parameter.Name));
         }
     }
 
-    private static bool HasCslaAttribute(ISymbol symbol, Func<string, bool> isAttribute, CancellationToken ct) {
-        var methodAttributes = symbol.GetAttributes();
-        if (methodAttributes.IsDefaultOrEmpty) {
+    private static bool HasPortalAttribute(ImmutableArray<AttributeData> attributes, ImmutableHashSet<INamedTypeSymbol> portalAttributeTypes, CancellationToken ct) {
+        for (var i = 0; i < attributes.Length; i++) {
+            ct.ThrowIfCancellationRequested();
+
+            if (attributes[i].AttributeClass is not null && portalAttributeTypes.Contains(attributes[i].AttributeClass!)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasInjectAttribute(IParameterSymbol parameter, INamedTypeSymbol injectAttribute, CancellationToken ct) {
+        var attributes = parameter.GetAttributes();
+        if (attributes.IsDefaultOrEmpty) {
             return false;
         }
 
-        for (var i = 0; i < methodAttributes.Length; i++) {
+        for (var i = 0; i < attributes.Length; i++) {
             ct.ThrowIfCancellationRequested();
 
-            var methodAttribute = methodAttributes[i];
-            if (methodAttribute.AttributeClass is { ContainingNamespace.Name: "Csla" } cslaAttribute && isAttribute(cslaAttribute.Name)) {
+            if (SymbolEqualityComparer.Default.Equals(attributes[i].AttributeClass, injectAttribute)) {
                 return true;
             }
         }

--- a/src/Csla.DataPortalExtensionGenerator.Analyzers/NotDataPortalExtensionMethodUsedAnalyzer.cs
+++ b/src/Csla.DataPortalExtensionGenerator.Analyzers/NotDataPortalExtensionMethodUsedAnalyzer.cs
@@ -30,26 +30,40 @@ public sealed class NotDataPortalExtensionMethodUsedAnalyzer : DiagnosticAnalyze
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
 
-        context.RegisterOperationAction(AnalyzeOperation, OperationKind.Invocation);
+        context.RegisterCompilationStartAction(compilationStart => {
+            var compilation = compilationStart.Compilation;
+
+            var dataPortal = CompilationHelper.ResolveType(compilation, "Csla.IDataPortal`1");
+            if (dataPortal is null) {
+                return;
+            }
+
+            var childDataPortal = CompilationHelper.ResolveType(compilation, "Csla.IChildDataPortal`1");
+            if (childDataPortal is null) {
+                return;
+            }
+
+            compilationStart.RegisterOperationAction(ctx => AnalyzeOperation(ctx, dataPortal, childDataPortal), OperationKind.Invocation);
+        });
     }
 
-    private void AnalyzeOperation(OperationAnalysisContext context) {
+    private static void AnalyzeOperation(OperationAnalysisContext context, INamedTypeSymbol dataPortal, INamedTypeSymbol childDataPortal) {
         var invocationExpression = (IInvocationOperation)context.Operation;
         var targetMethod = invocationExpression.TargetMethod;
 
         var methodName = targetMethod.Name;
 
-        string expectedType;
+        INamedTypeSymbol expectedType;
         switch (methodName) {
             case "CreateAsync":
             case "DeleteAsync":
             case "ExecuteAsync":
             case "FetchAsync":
-                expectedType = "IDataPortal";
+                expectedType = dataPortal;
                 break;
             case "CreateChildAsync":
             case "FetchChildAsync":
-                expectedType = "IChildDataPortal";
+                expectedType = childDataPortal;
                 break;
             case "UpdateAsync":
             case "UpdateChildAsync":
@@ -59,17 +73,9 @@ public sealed class NotDataPortalExtensionMethodUsedAnalyzer : DiagnosticAnalyze
 
         context.CancellationToken.ThrowIfCancellationRequested();
 
-        if (targetMethod.ContainingType is not { ContainingNamespace.Name: "Csla" } cslaType) {
+        if (!SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType.OriginalDefinition, expectedType)) {
             return;
         }
-
-        context.CancellationToken.ThrowIfCancellationRequested();
-
-        if (cslaType.Name != expectedType) {
-            return;
-        }
-
-        context.CancellationToken.ThrowIfCancellationRequested();
 
         context.ReportDiagnostic(Diagnostic.Create(_rule, invocationExpression.Syntax.GetLocation(), methodName));
     }

--- a/src/Csla.DataPortalExtensionGenerator.Analyzers/SynchronousDataPortalCallAnalyzer.cs
+++ b/src/Csla.DataPortalExtensionGenerator.Analyzers/SynchronousDataPortalCallAnalyzer.cs
@@ -30,26 +30,40 @@ public sealed class SynchronousDataPortalCallAnalyzer : DiagnosticAnalyzer {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
 
-        context.RegisterOperationAction(AnalyzeOperation, OperationKind.Invocation);
+        context.RegisterCompilationStartAction(compilationStart => {
+            var compilation = compilationStart.Compilation;
+
+            var dataPortal = CompilationHelper.ResolveType(compilation, "Csla.IDataPortal`1");
+            if (dataPortal is null) {
+                return;
+            }
+
+            var childDataPortal = CompilationHelper.ResolveType(compilation, "Csla.IChildDataPortal`1");
+            if (childDataPortal is null) {
+                return;
+            }
+
+            compilationStart.RegisterOperationAction(ctx => AnalyzeOperation(ctx, dataPortal, childDataPortal), OperationKind.Invocation);
+        });
     }
 
-    private void AnalyzeOperation(OperationAnalysisContext context) {
+    private static void AnalyzeOperation(OperationAnalysisContext context, INamedTypeSymbol dataPortal, INamedTypeSymbol childDataPortal) {
         var invocationExpression = (IInvocationOperation)context.Operation;
         var targetMethod = invocationExpression.TargetMethod;
 
         var methodName = targetMethod.Name;
 
-        string expectedType;
+        INamedTypeSymbol expectedType;
         switch (methodName) {
             case "Create":
             case "Delete":
             case "Execute":
             case "Fetch":
-                expectedType = "IDataPortal";
+                expectedType = dataPortal;
                 break;
             case "CreateChild":
             case "FetchChild":
-                expectedType = "IChildDataPortal";
+                expectedType = childDataPortal;
                 break;
             default:
                 return;
@@ -57,17 +71,9 @@ public sealed class SynchronousDataPortalCallAnalyzer : DiagnosticAnalyzer {
 
         context.CancellationToken.ThrowIfCancellationRequested();
 
-        if (targetMethod.ContainingType is not { ContainingNamespace.Name: "Csla" } cslaType) {
+        if (!SymbolEqualityComparer.Default.Equals(targetMethod.ContainingType.OriginalDefinition, expectedType)) {
             return;
         }
-
-        context.CancellationToken.ThrowIfCancellationRequested();
-
-        if (cslaType.Name != expectedType) {
-            return;
-        }
-
-        context.CancellationToken.ThrowIfCancellationRequested();
 
         context.ReportDiagnostic(Diagnostic.Create(_rule, invocationExpression.Syntax.GetLocation(), methodName));
     }

--- a/tests/Csla.DataPortalExtensionGenerator.Analyzers.Test/DataPortalInterfaceUsedAsNotInjectedParamterAnalyzerTests.cs
+++ b/tests/Csla.DataPortalExtensionGenerator.Analyzers.Test/DataPortalInterfaceUsedAsNotInjectedParamterAnalyzerTests.cs
@@ -22,6 +22,26 @@ public class Testing : Csla.Core.ICslaObject {{
         await VerifyCS.VerifyAnalyzerAsync(cslaSource);
     }
 
+    [Fact]
+    public async Task UserTypeInNestedCslaNamespaceMustNotTriggerDPEG1001() {
+        var cslaSource = @"
+using Csla;
+
+namespace Acme.Csla {
+
+    public interface IDataPortal<T> {
+    }
+
+    public class Testing : global::Csla.Core.ICslaObject {
+
+        [Fetch]
+        private void Foo(string a, IDataPortal<Testing> portal){
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(cslaSource);
+    }
+
     [Theory]
     [InlineData("IDataPortal")]
     [InlineData("IChildDataPortal")]

--- a/tests/Csla.DataPortalExtensionGenerator.Analyzers.Test/NotDataPortalExtensionMethodUsedAnalyzerTests.cs
+++ b/tests/Csla.DataPortalExtensionGenerator.Analyzers.Test/NotDataPortalExtensionMethodUsedAnalyzerTests.cs
@@ -99,6 +99,25 @@ namespace TestNamespace {{
     }
 
     [Fact]
+    public async Task UserTypeInNestedCslaNamespaceMustNotTriggerDPEG1000() {
+        var cslaSource = @"
+namespace Acme.Csla {
+
+    public interface IDataPortal<T> {
+        System.Threading.Tasks.Task<T> FetchAsync();
+    }
+
+    public class Testing {
+        public async System.Threading.Tasks.Task Test1() {
+            IDataPortal<Testing> fooPortal = null!;
+            var x = await fooPortal.FetchAsync();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(cslaSource);
+    }
+
+    [Fact]
     public async Task IChildDataPortalUpdateMustNotGetDiagnosticDPEG1000() {
         var cslaSource = @$"
 using Csla;

--- a/tests/Csla.DataPortalExtensionGenerator.Analyzers.Test/SynchronousDataPortalCallAnalyzerTests.cs
+++ b/tests/Csla.DataPortalExtensionGenerator.Analyzers.Test/SynchronousDataPortalCallAnalyzerTests.cs
@@ -109,6 +109,25 @@ namespace TestNamespace {
     }
 
     [Fact]
+    public async Task UserTypeInNestedCslaNamespaceMustNotTriggerDPEG1002() {
+        var cslaSource = @"
+namespace Acme.Csla {
+
+    public interface IDataPortal<T> {
+        T Fetch();
+    }
+
+    public class Testing {
+        public void Test1() {
+            IDataPortal<Testing> portal = null!;
+            var x = portal.Fetch();
+        }
+    }
+}";
+        await VerifyCS.VerifyAnalyzerAsync(cslaSource);
+    }
+
+    [Fact]
     public async Task NonCslaFetchMustNotTriggerDPEG1002() {
         var cslaSource = @"
 namespace TestNamespace {


### PR DESCRIPTION
## Summary
- Analyzers previously matched types by checking the leaf namespace `"Csla"`, which caused false positives when other namespaces contained types named like CSLA types. Switched all three analyzers to use `RegisterCompilationStartAction` with `GetTypeByMetadataName` and `SymbolEqualityComparer` for correct full-name matching.
- Made `InjectAttribute` resolution non-nullable in DPEG1001 analyzer since it must be present when data portal types are available.
- Minor code cleanup to reduce duplication across analyzers.
- Added negative tests verifying analyzers do not flag types from non-Csla namespaces.

## Test plan
- [x] Existing analyzer tests pass
- [x] New negative tests verify no false positives for types in non-Csla namespaces