### PR TITLE
Back SupportedDiagnostics with static readonly field

### DIFF
--- a/src/Csla.DataPortalExtensionGenerator.Analyzers/DataPortalInterfaceUsedAsNotInjectedParamterAnalyzer.cs
+++ b/src/Csla.DataPortalExtensionGenerator.Analyzers/DataPortalInterfaceUsedAsNotInjectedParamterAnalyzer.cs
@@ -22,8 +22,10 @@ public sealed class DataPortalInterfaceUsedAsNotInjectedParamterAnalyzer : Diagn
 
     private static readonly DiagnosticDescriptor _rule = new(DiagnosticId, _title, _messageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: _description);
 
+    private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics = ImmutableArray.Create(_rule);
+
     /// <inheritdoc />
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => _supportedDiagnostics;
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context) {

--- a/src/Csla.DataPortalExtensionGenerator.Analyzers/NotDataPortalExtensionMethodUsedAnalyzer.cs
+++ b/src/Csla.DataPortalExtensionGenerator.Analyzers/NotDataPortalExtensionMethodUsedAnalyzer.cs
@@ -22,8 +22,10 @@ public sealed class NotDataPortalExtensionMethodUsedAnalyzer : DiagnosticAnalyze
 
     private static readonly DiagnosticDescriptor _rule = new(DiagnosticId, _title, _messageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: _description);
 
+    private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics = ImmutableArray.Create(_rule);
+
     /// <inheritdoc />
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => _supportedDiagnostics;
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context) {

--- a/src/Csla.DataPortalExtensionGenerator.Analyzers/SynchronousDataPortalCallAnalyzer.cs
+++ b/src/Csla.DataPortalExtensionGenerator.Analyzers/SynchronousDataPortalCallAnalyzer.cs
@@ -22,8 +22,10 @@ public sealed class SynchronousDataPortalCallAnalyzer : DiagnosticAnalyzer {
 
     private static readonly DiagnosticDescriptor _rule = new(DiagnosticId, _title, _messageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, description: _description);
 
+    private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics = ImmutableArray.Create(_rule);
+
     /// <inheritdoc />
-    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(_rule);
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => _supportedDiagnostics;
 
     /// <inheritdoc />
     public override void Initialize(AnalysisContext context) {


### PR DESCRIPTION
## Summary
- Cache `SupportedDiagnostics` in a `static readonly` field instead of creating a new `ImmutableArray` on every property access across all three analyzers.

## Test plan
- [x] All existing analyzer tests pass